### PR TITLE
Use 1xx as expected response when requesting a data connection

### DIFF
--- a/ftps.go
+++ b/ftps.go
@@ -223,7 +223,7 @@ func (ftps *FTPS) List() (entries []Entry, err error) {
 
 	// TODO add support for MLSD
 
-	dataConn, err := ftps.requestDataConn("LIST -a", 150) // TODO use also -L to resolve links?
+	dataConn, err := ftps.requestDataConn("LIST -a", 1) // TODO use also -L to resolve links?
 	if err != nil {
 		return
 	}
@@ -304,7 +304,7 @@ func (ftps *FTPS) parseEntryLine(line string) (entry *Entry, err error) {
 
 func (ftps *FTPS) StoreFile(remoteFilepath string, data []byte) (err error) {
 
-	dataConn, err := ftps.requestDataConn(fmt.Sprintf("STOR %s", remoteFilepath), 150)
+	dataConn, err := ftps.requestDataConn(fmt.Sprintf("STOR %s", remoteFilepath), 1)
 	if err != nil {
 		return
 	}
@@ -330,7 +330,7 @@ func (ftps *FTPS) StoreFile(remoteFilepath string, data []byte) (err error) {
 
 func (ftps *FTPS) RetrieveFileData(remoteFilepath string) (data []byte, err error) {
 
-	dataConn, err := ftps.requestDataConn(fmt.Sprintf("RETR %s", remoteFilepath), 150)
+	dataConn, err := ftps.requestDataConn(fmt.Sprintf("RETR %s", remoteFilepath), 1)
 	if err != nil {
 		return
 	}
@@ -360,7 +360,7 @@ func (ftps *FTPS) RetrieveFileData(remoteFilepath string) (data []byte, err erro
 
 func (ftps *FTPS) RetrieveFile(remoteFilepath, localFilepath string) (err error) {
 
-	dataConn, err := ftps.requestDataConn(fmt.Sprintf("RETR %s", remoteFilepath), 150)
+	dataConn, err := ftps.requestDataConn(fmt.Sprintf("RETR %s", remoteFilepath), 1)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
I have an issue where when I call `StoreFile`, the server responds with `125 Data connection already open; Transfer starting.`, which this library treats as an unexpected code and incorrectly aborts the transfer.

I don't have control over this server, and I'm not sure why it is responding this way (I am only opening one connection in a simple script to store one file, and I always close the connection afterwards). But regardless, 125 is not actually an error code, and if we treat it as a success code the file still gets uploaded just fine.

So this commit changes the expected response to 1xx, which should match any positive response, as described [here](https://en.wikipedia.org/wiki/List_of_FTP_server_return_codes).