### PR TITLE
Accept valid preliminary data responses

### DIFF
--- a/ftps.go
+++ b/ftps.go
@@ -223,7 +223,7 @@ func (ftps *FTPS) List() (entries []Entry, err error) {
 
 	// TODO add support for MLSD
 
-	dataConn, err := ftps.requestDataConn("LIST -a", 150) // TODO use also -L to resolve links?
+	dataConn, err := ftps.requestDataConn("LIST -a", 1) // TODO use also -L to resolve links?
 	if err != nil {
 		return
 	}
@@ -304,7 +304,7 @@ func (ftps *FTPS) parseEntryLine(line string) (entry *Entry, err error) {
 
 func (ftps *FTPS) StoreFile(remoteFilepath string, data []byte) (err error) {
 
-	dataConn, err := ftps.requestDataConn(fmt.Sprintf("STOR %s", remoteFilepath), 150)
+	dataConn, err := ftps.requestDataConn(fmt.Sprintf("STOR %s", remoteFilepath), 1)
 	if err != nil {
 		return
 	}
@@ -330,7 +330,7 @@ func (ftps *FTPS) StoreFile(remoteFilepath string, data []byte) (err error) {
 
 func (ftps *FTPS) RetrieveFileData(remoteFilepath string) (data []byte, err error) {
 
-	dataConn, err := ftps.requestDataConn(fmt.Sprintf("RETR %s", remoteFilepath), 150)
+	dataConn, err := ftps.requestDataConn(fmt.Sprintf("RETR %s", remoteFilepath), 1)
 	if err != nil {
 		return
 	}
@@ -360,7 +360,7 @@ func (ftps *FTPS) RetrieveFileData(remoteFilepath string) (data []byte, err erro
 
 func (ftps *FTPS) RetrieveFile(remoteFilepath, localFilepath string) (err error) {
 
-	dataConn, err := ftps.requestDataConn(fmt.Sprintf("RETR %s", remoteFilepath), 150)
+	dataConn, err := ftps.requestDataConn(fmt.Sprintf("RETR %s", remoteFilepath), 1)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- accept the RFC 959 preliminary data-transfer responses `125` and `150`
- continue rejecting unrelated `1xx` responses such as `110` and `120`
- add regression coverage for `StoreFile` with these responses

Supersedes #4 because its head repository is archived and cannot receive maintainer updates. The original `125` compatibility fix was contributed by @suddjian in #4, and their original commit remains in this branch history.

## Testing
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go test -run '^TestStoreFilePreliminaryResponse$' -count=20 -v`